### PR TITLE
Add Parent Ally responsive site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Parent Ally</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Parent Ally</h1>
+        <p>Guiding your parenting journey with best practices</p>
+    </header>
+    <main>
+        <section id="styles">
+            <h2>Parenting Styles</h2>
+            <div class="cards">
+                <!-- Cards for styles will be inserted here -->
+            </div>
+        </section>
+        <section id="methods">
+            <h2>Educational & Parenting Methods</h2>
+            <div class="cards">
+                <!-- Cards for methods will be inserted here -->
+            </div>
+        </section>
+        <section id="journeys">
+            <h2>Guided Journeys</h2>
+            <p>Core ideas distilled from respected sources to cultivate confident, compassionate leaders.</p>
+            <ul>
+                <li>Encourage independence and responsibility daily.</li>
+                <li>Model empathy and patience through every interaction.</li>
+                <li>Create rhythm and structure to nurture security.</li>
+                <li>Invite curiosity with nature walks, hands-on projects, and storytelling.</li>
+                <li>Share purposeful habits rooted in kindness and resilience.</li>
+            </ul>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Parent Ally</p>
+    </footer>
+    <script src="scripts.js"></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,55 @@
+const styles = [
+    { name: 'Authoritative', summary: 'High expectations with warmth and respect.', good: 80, bad: 20 },
+    { name: 'Authoritarian', summary: 'Strict rules and obedience focus.', good: 60, bad: 40 },
+    { name: 'Permissive', summary: 'Lenient with few demands.', good: 70, bad: 50 },
+    { name: 'Uninvolved', summary: 'Low responsiveness and guidance.', good: 30, bad: 70 },
+    { name: 'Positive/Gentle', summary: 'Empathy and natural consequences.', good: 85, bad: 25 },
+    { name: 'Helicopter', summary: 'Overprotective and involved.', good: 60, bad: 40 },
+    { name: 'Free-Range', summary: 'Encourages independence within boundaries.', good: 75, bad: 30 },
+    { name: 'Tiger', summary: 'Achievement-focused discipline.', good: 70, bad: 50 }
+];
+
+const methods = [
+    { name: 'Montessori', summary: 'Self-directed activity in prepared environments.', good: 80, bad: 30 },
+    { name: 'Waldorf', summary: 'Arts-based learning with daily rhythm.', good: 70, bad: 40 },
+    { name: 'Reggio Emilia', summary: 'Project-based child-led discovery.', good: 75, bad: 35 },
+    { name: 'Charlotte Mason', summary: 'Short lessons using living books.', good: 70, bad: 30 },
+    { name: 'Unschooling', summary: 'Learning from life experiences.', good: 65, bad: 45 },
+    { name: 'Forest School', summary: 'Outdoor nature-rich exploration.', good: 80, bad: 30 },
+    { name: 'Classical Education', summary: 'Grammar, Logic, Rhetoric.', good: 70, bad: 40 },
+    { name: 'RIE', summary: 'Respectful infant caregiving.', good: 85, bad: 20 },
+    { name: 'Pikler', summary: 'Independent motor development.', good: 80, bad: 25 },
+    { name: 'Faith-Based', summary: 'Guided by scripture and moral character.', good: 85, bad: 30 }
+];
+
+function createCard(item) {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const title = document.createElement('h3');
+    title.textContent = item.name;
+    const summary = document.createElement('p');
+    summary.textContent = item.summary;
+    const goodMeter = document.createElement('div');
+    goodMeter.className = 'meter';
+    const goodBar = document.createElement('div');
+    goodBar.style.width = item.good + '%';
+    goodMeter.appendChild(goodBar);
+    const badMeter = document.createElement('div');
+    badMeter.className = 'meter';
+    const badBar = document.createElement('div');
+    badBar.style.width = item.bad + '%';
+    badBar.style.background = '#ff9e9e';
+    badMeter.appendChild(badBar);
+    card.appendChild(title);
+    card.appendChild(summary);
+    card.appendChild(goodMeter);
+    card.appendChild(badMeter);
+    return card;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const styleContainer = document.querySelector('#styles .cards');
+    const methodContainer = document.querySelector('#methods .cards');
+    styles.forEach(item => styleContainer.appendChild(createCard(item)));
+    methods.forEach(item => methodContainer.appendChild(createCard(item)));
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,58 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #e0e0e0;
+    color: #333;
+}
+header {
+    text-align: center;
+    padding: 2rem 1rem;
+    background: #e0e0e0;
+    box-shadow: 9px 9px 16px #bebebe, -9px -9px 16px #ffffff;
+}
+header h1 {
+    margin: 0.2rem;
+}
+main {
+    padding: 1rem;
+}
+.cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+.card {
+    background: #e0e0e0;
+    border-radius: 12px;
+    box-shadow: 9px 9px 16px #bebebe, -9px -9px 16px #ffffff;
+    padding: 1rem;
+    width: 280px;
+    box-sizing: border-box;
+}
+.card h3 {
+    margin-top: 0;
+}
+.meter {
+    background: #d1d1d1;
+    border-radius: 10px;
+    overflow: hidden;
+    height: 10px;
+    margin-bottom: 0.5rem;
+}
+.meter div {
+    height: 100%;
+    background: #76a3ff;
+}
+footer {
+    text-align: center;
+    padding: 1rem;
+    background: #e0e0e0;
+    box-shadow: inset 9px 9px 16px #bebebe, inset -9px -9px 16px #ffffff;
+}
+@media (max-width: 600px) {
+    .card {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- build initial Parent Ally site with neumorphic style
- add cards for parenting styles and methods
- show simple strength/weakness meters for each method
- include a short guided journey section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68471290a8f48328aa90d1829192aff4