### PR TITLE
Improve trait display and add resource modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Parent Ally
 
-This demo showcases parenting styles and educational methods. Click each card to reveal strengths fostered and traits that may be overlooked. The layout is responsive for mobile and desktop.
+This demo showcases parenting styles and educational methods. Each card displays overall strengths and potential blind spots using blue and red meters. Clicking a card opens a modal with traits and helpful links for videos and books. The layout is responsive for mobile and desktop.

--- a/index.html
+++ b/index.html
@@ -38,6 +38,19 @@
             </ul>
         </section>
     </main>
+    <div id="infoModal" class="modal">
+        <div class="modal-content">
+            <span id="modalClose" class="modal-close">&times;</span>
+            <h3 id="modalTitle"></h3>
+            <p id="modalSummary"></p>
+            <div id="modalTraits"></div>
+            <div class="resource-links">
+                <h4>Explore More</h4>
+                <ul id="modalVideos"></ul>
+                <ul id="modalBooks"></ul>
+            </div>
+        </div>
+    </div>
     <footer>
         <p>&copy; 2023 Parent Ally</p>
     </footer>

--- a/scripts.js
+++ b/scripts.js
@@ -148,6 +148,85 @@ const methods = [
     }
 ];
 
+function getResources(name) {
+    return {
+        videos: [
+            `https://www.youtube.com/results?search_query=${encodeURIComponent(name + ' parenting method')}`
+        ],
+        books: [
+            `https://www.goodreads.com/search?q=${encodeURIComponent(name + ' parenting')}`
+        ]
+    };
+}
+
+function showModal(item) {
+    const modal = document.getElementById('infoModal');
+    const modalTitle = document.getElementById('modalTitle');
+    const modalSummary = document.getElementById('modalSummary');
+    const modalTraits = document.getElementById('modalTraits');
+    const modalVideos = document.getElementById('modalVideos');
+    const modalBooks = document.getElementById('modalBooks');
+
+    modalTitle.textContent = item.name;
+    modalSummary.textContent = item.summary;
+
+    modalTraits.innerHTML = '';
+    const growTitle = document.createElement('h4');
+    growTitle.textContent = 'Fosters';
+    const growList = document.createElement('ul');
+    item.grows.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = t;
+        growList.appendChild(li);
+    });
+    const neglectTitle = document.createElement('h4');
+    neglectTitle.textContent = 'May Neglect';
+    const neglectList = document.createElement('ul');
+    item.neglects.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = t;
+        neglectList.appendChild(li);
+    });
+    modalTraits.appendChild(growTitle);
+    modalTraits.appendChild(growList);
+    modalTraits.appendChild(neglectTitle);
+    modalTraits.appendChild(neglectList);
+
+    const resources = getResources(item.name);
+    modalVideos.innerHTML = '';
+    resources.videos.forEach(url => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = url;
+        a.target = '_blank';
+        a.textContent = `YouTube search for ${item.name}`;
+        li.appendChild(a);
+        modalVideos.appendChild(li);
+    });
+    modalBooks.innerHTML = '';
+    resources.books.forEach(url => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = url;
+        a.target = '_blank';
+        a.textContent = `Books about ${item.name}`;
+        li.appendChild(a);
+        modalBooks.appendChild(li);
+    });
+
+    modal.classList.add('active');
+}
+
+document.getElementById('modalClose').addEventListener('click', () => {
+    document.getElementById('infoModal').classList.remove('active');
+});
+
+document.getElementById('infoModal').addEventListener('click', e => {
+    if (e.target.id === 'infoModal') {
+        e.target.classList.remove('active');
+    }
+});
+
 
 function createCard(item) {
     const card = document.createElement('div');
@@ -156,17 +235,32 @@ function createCard(item) {
     title.textContent = item.name;
     const summary = document.createElement('p');
     summary.textContent = item.summary;
+    const goodWrap = document.createElement('div');
+    goodWrap.className = 'meter-container';
+    const goodLabel = document.createElement('span');
+    goodLabel.className = 'meter-label';
+    goodLabel.textContent = 'Strengths';
     const goodMeter = document.createElement('div');
     goodMeter.className = 'meter';
     const goodBar = document.createElement('div');
     goodBar.style.width = item.good + '%';
     goodMeter.appendChild(goodBar);
+    goodWrap.appendChild(goodLabel);
+    goodWrap.appendChild(goodMeter);
+
+    const badWrap = document.createElement('div');
+    badWrap.className = 'meter-container';
+    const badLabel = document.createElement('span');
+    badLabel.className = 'meter-label';
+    badLabel.textContent = 'Blind Spots';
     const badMeter = document.createElement('div');
     badMeter.className = 'meter';
     const badBar = document.createElement('div');
     badBar.style.width = item.bad + '%';
     badBar.style.background = '#ff9e9e';
     badMeter.appendChild(badBar);
+    badWrap.appendChild(badLabel);
+    badWrap.appendChild(badMeter);
 
     const details = document.createElement('div');
     details.className = 'details';
@@ -193,12 +287,12 @@ function createCard(item) {
 
     card.appendChild(title);
     card.appendChild(summary);
-    card.appendChild(goodMeter);
-    card.appendChild(badMeter);
+    card.appendChild(goodWrap);
+    card.appendChild(badWrap);
     card.appendChild(details);
 
     card.addEventListener('click', () => {
-        details.classList.toggle('visible');
+        showModal(item);
     });
 
     return card;

--- a/styles.css
+++ b/styles.css
@@ -50,13 +50,7 @@ main {
     box-shadow: 12px 12px 24px #bebebe, -12px -12px 24px #ffffff;
 }
 .details {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.3s ease;
     margin-top: 0.5rem;
-}
-.details.visible {
-    max-height: 400px;
 }
 .details h4 {
     margin: 0.5rem 0 0.2rem;
@@ -79,6 +73,55 @@ main {
 .meter div {
     height: 100%;
     background: #76a3ff;
+}
+
+.meter-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.meter-label {
+    font-size: 0.85rem;
+    width: 120px;
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    z-index: 1000;
+}
+
+.modal.active {
+    display: flex;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    max-width: 600px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+}
+
+.modal-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    font-size: 1.5rem;
+    cursor: pointer;
 }
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- clarify blue and red meters by labeling them Strengths and Blind Spots
- show traits on each card and open a modal with more info
- provide links to video and book searches in the modal
- add styles for the modal overlay
- document new behaviour in README

## Testing
- `node --check scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_684716dc83d483288ca32953b7afcac5