### PR TITLE
Improve radar chart UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Cards now include emoji icons and expandable sections for strengths and blind sp
 A smart search bar offers suggestions as you type and highlights matching cards.
 The radar chart loads on demand and animates smoothly when a card is selected.
 A mobile bottom navigation bar and floating help button improve the mobile experience.
+The chart now floats on the side of the screen with a toggle to hide or show it and automatically fades while scrolling.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         <aside id="radarContainer" class="chart-container">
             <canvas id="radarChart" aria-label="Traits radar chart"></canvas>
         </aside>
+        <button id="chartToggle" class="chart-toggle">Hide Chart</button>
         <section id="styles">
             <h2>Parenting Styles</h2>
             <p class="hint">Click a card to learn which traits it encourages or may overlook.</p>

--- a/scripts.js
+++ b/scripts.js
@@ -390,7 +390,22 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
-    chartObserver.observe(document.getElementById('radarContainer'));
+    const radarContainer = document.getElementById('radarContainer');
+    chartObserver.observe(radarContainer);
+
+    const chartToggle = document.getElementById('chartToggle');
+    chartToggle.addEventListener('click', () => {
+        radarContainer.classList.toggle('hidden');
+        chartToggle.textContent = radarContainer.classList.contains('hidden') ? 'Show Chart' : 'Hide Chart';
+    });
+
+    window.addEventListener('scroll', () => {
+        if (window.scrollY > 150) {
+            radarContainer.classList.add('faded');
+        } else {
+            radarContainer.classList.remove('faded');
+        }
+    });
 
     const observer = new IntersectionObserver(entries => {
         entries.forEach(entry => {

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,10 @@ header h1 {
 main {
     padding: 1rem;
 }
+
+@media (min-width: 769px) {
+    main { margin-right: 340px; }
+}
 .hint {
     text-align: center;
     font-size: 0.9rem;
@@ -60,6 +64,8 @@ main {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    position: relative;
+    z-index: 1;
 }
 .card.visible {
     opacity: 1;
@@ -208,17 +214,53 @@ footer {
 .chart-container {
     position: fixed;
     right: 1rem;
-    top: 5rem;
+    top: 50%;
+    transform: translateY(-50%);
     width: 300px;
     height: 300px;
     background: var(--surface);
     border-radius: 12px;
     box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light);
     overflow: hidden;
-    transition: transform 0.3s ease;
+    z-index: 1000;
+    transition: transform 0.3s ease, opacity 0.3s ease;
 }
-.chart-container:hover { transform: scale(1.05); }
+.chart-container:hover { transform: translateY(-50%) scale(1.05); }
 .chart-container canvas { width: 100%; height: 100%; }
+.chart-container.hidden { opacity: 0; pointer-events: none; }
+.chart-container.faded { opacity: 0; }
+
+.chart-toggle {
+    position: fixed;
+    right: 1rem;
+    top: calc(50% + 160px);
+    z-index: 1001;
+    border: none;
+    padding: 0.4rem 0.8rem;
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    cursor: pointer;
+}
+
+@media (max-width: 768px) {
+    .chart-container {
+        top: auto;
+        bottom: 1rem;
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+        width: 90%;
+        height: 250px;
+    }
+    .chart-toggle {
+        top: auto;
+        bottom: calc(250px + 1.5rem);
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+    }
+}
 
 .card.active {
     transform: scale(1.02);


### PR DESCRIPTION
## Summary
- position radar chart as fixed sidebar and add mobile layout
- add button to hide/show radar chart
- fade chart on scroll and prevent overlap with cards

## Testing
- `npx --yes serve` *(manual visual check)*

------
https://chatgpt.com/codex/tasks/task_e_684832ec9b548328b15f03e59f9d898f